### PR TITLE
fixed typo in scope_method.cson

### DIFF
--- a/snippets/scope_method.cson
+++ b/snippets/scope_method.cson
@@ -1,4 +1,4 @@
-``'.source.js':
+'.source.js':
   'Private Method':
     'prefix': '_sm'
     'body': """


### PR DESCRIPTION
there is a typo in `scope_method.cson` - the PR should fix it

this is the message in dev tools:

```
Error reading snippets file '/Users/username/.atom/packages/angularjs-snippets/snippets/scope_method.cson': [stdin]:1:15: error: unexpected :
``'.source.js':
              ^ /Applications/Atom.app/Contents/Resources/app/node_modules/snippets/lib/snippets.js:132
```
